### PR TITLE
Update Python requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,62 +4,62 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements-dev.in
 #
-ansible==4.4.0
+ansible==4.6.0
     # via -r requirements-dev.in
-ansible-core==2.11.3
-    # via ansible
-ansible-lint==5.1.2
+ansible-compat==0.5.0
     # via
-    #   -r requirements-dev.in
     #   molecule
-appdirs==1.4.4
-    # via black
-arrow==0.15.8
+    #   molecule-docker
+ansible-core==2.11.5
+    # via ansible
+ansible-lint==5.2.0
+    # via -r requirements-dev.in
+arrow==1.2.0
     # via jinja2-time
-attrs==19.3.0
+attrs==21.2.0
     # via pytest
-bcrypt==3.1.7
+bcrypt==3.2.0
     # via paramiko
 binaryornot==0.4.4
     # via cookiecutter
-black==21.7b0
+black==21.9b0
     # via -r requirements-dev.in
 bracex==2.1.1
     # via wcmatch
 cerberus==1.3.2
     # via molecule
-certifi==2020.6.20
+certifi==2021.5.30
     # via requests
-cffi==1.14.1
+cffi==1.14.6
     # via
     #   bcrypt
     #   cryptography
     #   pynacl
-chardet==3.0.4
-    # via
-    #   binaryornot
-    #   requests
+chardet==4.0.0
+    # via binaryornot
+charset-normalizer==2.0.6
+    # via requests
 click==8.0.1
     # via
     #   black
     #   click-help-colors
     #   cookiecutter
     #   molecule
-click-help-colors==0.9
+click-help-colors==0.9.1
     # via molecule
-colorama==0.4.3
+colorama==0.4.4
     # via rich
 commonmark==0.9.1
     # via rich
 cookiecutter==1.7.3
     # via molecule
-cryptography==3.3.2
+cryptography==35.0.0
     # via
     #   ansible-core
     #   paramiko
-distro==1.5.0
+distro==1.6.0
     # via selinux
-docker==4.4.3
+docker==5.0.2
     # via molecule-docker
 enrich==1.2.6
     # via
@@ -74,13 +74,13 @@ flake8-docstrings==1.6.0
     # via -r requirements-dev.in
 flake8-isort==4.0.0
     # via -r requirements-dev.in
-idna==2.10
+idna==3.2
     # via requests
-iniconfig==1.0.0
+iniconfig==1.1.1
     # via pytest
 isort==5.9.3
     # via flake8-isort
-jinja2==2.11.3
+jinja2==3.0.2
     # via
     #   ansible-core
     #   cookiecutter
@@ -88,31 +88,31 @@ jinja2==2.11.3
     #   molecule
 jinja2-time==0.2.0
     # via cookiecutter
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
-molecule==3.4.0
+molecule==3.5.2
     # via
     #   -r requirements-dev.in
     #   molecule-docker
-molecule-docker==0.2.4
+molecule-docker==1.0.2
     # via -r requirements-dev.in
-more-itertools==8.4.0
-    # via pytest
 mypy-extensions==0.4.3
     # via black
-packaging==20.4
+packaging==21.0
     # via
     #   ansible-core
     #   ansible-lint
     #   molecule
     #   pytest
-paramiko==2.7.1
+paramiko==2.7.2
     # via molecule
 pathspec==0.9.0
     # via black
-pluggy==0.13.1
+platformdirs==2.4.0
+    # via black
+pluggy==1.0.0
     # via
     #   molecule
     #   pytest
@@ -128,39 +128,41 @@ pydocstyle==6.1.1
     # via flake8-docstrings
 pyflakes==2.3.1
     # via flake8
-pygments==2.8.0
+pygments==2.10.0
     # via rich
 pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
     # via packaging
-pytest==6.0.1
+pytest==6.2.5
     # via pytest-testinfra
 pytest-testinfra==6.4.0
     # via -r requirements-dev.in
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via arrow
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via cookiecutter
-pyyaml==5.4
+pyyaml==5.4.1
     # via
+    #   ansible-compat
     #   ansible-core
     #   ansible-lint
     #   molecule
-regex==2021.8.3
+regex==2021.9.30
     # via black
-requests==2.25.1
+requests==2.26.0
     # via
     #   cookiecutter
     #   docker
+    #   molecule-docker
 resolvelib==0.5.4
     # via ansible-core
-rich==9.11.1
+rich==10.12.0
     # via
     #   ansible-lint
     #   enrich
     #   molecule
-ruamel.yaml==0.16.10
+ruamel.yaml==0.17.16
     # via ansible-lint
 ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
@@ -168,38 +170,33 @@ selinux==0.2.1
     # via
     #   molecule
     #   molecule-docker
-six==1.15.0
+six==1.16.0
     # via
     #   bcrypt
     #   cookiecutter
-    #   cryptography
-    #   docker
-    #   packaging
     #   pynacl
     #   python-dateutil
-    #   tenacity
-    #   websocket-client
 snowballstemmer==2.1.0
     # via pydocstyle
-subprocess-tee==0.3.2
+subprocess-tee==0.3.5
     # via molecule
-tenacity==7.0.0
+tenacity==8.0.1
     # via ansible-lint
-testfixtures==6.18.1
+testfixtures==6.18.3
     # via flake8-isort
 text-unidecode==1.3
     # via python-slugify
-toml==0.10.1
+toml==0.10.2
     # via pytest
 tomli==1.2.1
     # via black
-typing-extensions==3.7.4.3
-    # via rich
-urllib3==1.26.5
+typing-extensions==3.10.0.2
+    # via black
+urllib3==1.26.7
     # via requests
-wcmatch==8.1.1
+wcmatch==8.2
     # via ansible-lint
-websocket-client==0.57.0
+websocket-client==1.2.1
     # via docker
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
As we do not (yet) have dependabot fully up-and-running in this
repository, we need to manually update the Python requirements in
order to fix flakey molecule tests.
