### PR TITLE
Remove ansible pip package from requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,4 @@
-ansible
+ansible-core
 ansible-lint
 black
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,15 +4,13 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements-dev.in
 #
-ansible==6.1.0
-    # via -r requirements-dev.in
 ansible-compat==2.1.0
     # via
     #   ansible-lint
     #   molecule
 ansible-core==2.13.1
     # via
-    #   ansible
+    #   -r requirements-dev.in
     #   ansible-lint
 ansible-lint==6.3.0
     # via -r requirements-dev.in


### PR DESCRIPTION
Now that we have specified all collections this role requires in the requirements.yml file, we can remove this legacy package.