### PR TITLE
Quote templated variables correctly

### DIFF
--- a/.github/workflows/update-python.yml
+++ b/.github/workflows/update-python.yml
@@ -20,7 +20,7 @@ jobs:
           import requests
 
           PR_NUM = ${{ github.event.pull_request.number }}
-          REPO_SLUG = ${{ github.repository }}
+          REPO_SLUG = "${{ github.repository }}"
 
           r = requests.post(
             f"https://api.github.com/repos/{REPO_SLUG}/issues/{PR_NUM}/comments",


### PR DESCRIPTION
 is a template variable, not a string, and without quotes this action throws .