### PR TITLE
Update ableton-utils to 0.24.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library(identifier: 'ableton-utils@0.23', changelog: false)
+library(identifier: 'ableton-utils@0.24', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
 library(identifier: 'python-utils@0.13', changelog: false)
 

--- a/molecule/bionic-build/converge.yml
+++ b/molecule/bionic-build/converge.yml
@@ -14,4 +14,4 @@
       - clang
       - clang++
   roles:
-    - ansible-role-ccache
+    - ableton.ccache

--- a/molecule/focal-github/converge.yml
+++ b/molecule/focal-github/converge.yml
@@ -13,4 +13,4 @@
       - clang++
     ccache_version: "4.8.1"
   roles:
-    - ansible-role-ccache
+    - ableton.ccache

--- a/molecule/focal-package/converge.yml
+++ b/molecule/focal-package/converge.yml
@@ -14,4 +14,4 @@
       - clang
       - clang++
   roles:
-    - ansible-role-ccache
+    - ableton.ccache


### PR DESCRIPTION
This update contains some improvements with how Ansible roles are tested with Molecule that will allow us to remove some of our hacks regarding role naming in the Molecule configuration files.